### PR TITLE
Update gemspec to match change in project name

### DIFF
--- a/defra_ruby_style.gemspec
+++ b/defra_ruby_style.gemspec
@@ -7,12 +7,12 @@ require "defra/style/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |spec|
-  spec.name        = "defra-style"
+  spec.name        = "defra_ruby_style"
   spec.version     = Defra::Style::VERSION.dup
   spec.authors     = ["Defra"]
   spec.email       = ["alan.cruikshanks@environment-agency.gov.uk"]
   spec.license     = "The Open Government Licence (OGL) Version 3"
-  spec.homepage    = "https://github.com/DEFRA/defra_style"
+  spec.homepage    = "https://github.com/DEFRA/defra-ruby-style"
   spec.summary     = "Defra ruby coding standards"
   spec.description = "A gem to simplify the process of ensuring ruby based "\
                      "Defra projects are using our agreed coding style and "\


### PR DESCRIPTION
We have updated the project name from **Defra style** to **Defra ruby style** to ensure this is not confused as a gem used to govern all styles in Defra.

As such this meant we needed to change the name of the gemspec file, plus some of the details in it.

This also fixes #2