### PR TITLE
Remove bundler as dev dependency

### DIFF
--- a/defra_ruby_style.gemspec
+++ b/defra_ruby_style.gemspec
@@ -36,6 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop", "~> 0.58.2"
   spec.add_dependency "rubocop-rspec", "~> 1.29.1"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
As you need bundler installed to then install the dependencies, we have decided there is not much value in specifing bundler as a dependency.