### PR TITLE
Remove rake as dev dependency

### DIFF
--- a/defra_ruby_style.gemspec
+++ b/defra_ruby_style.gemspec
@@ -35,6 +35,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rubocop", "~> 0.58.2"
   spec.add_dependency "rubocop-rspec", "~> 1.29.1"
-
-  spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
As we currently have no rake tasks in the project, we have decided there is not much value in specifying rake as a dependency.