### PR TITLE
Remove rubocop-rspec as a dependency

### DIFF
--- a/defra_ruby_style.gemspec
+++ b/defra_ruby_style.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rubocop", "~> 0.58.2"
-  spec.add_dependency "rubocop-rspec", "~> 1.29.1"
 end


### PR DESCRIPTION
We are not currently using [rubocop-rspec](https://github.com/rubocop-hq/rubocop-rspec) in our projects, though we probably should be.

So until we are ready to adopt it, we should not include it in defra-ruby-style as it might cause issues or inconsistencies across projects.