### PR TITLE
Remove version from rubocop

### DIFF
--- a/defra_ruby_style.gemspec
+++ b/defra_ruby_style.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
-  spec.add_dependency "rubocop", "~> 0.58.2"
+  spec.add_dependency "rubocop"
 end


### PR DESCRIPTION
In our latest projects we have simply stated rubocop as a dependency, and not assigned a version. This means we are always pulling in the latest, and with dependabot we can control if and when we take a version.

We'd rather know that a style has changed or been introduced, and experience has shown us we quickly make a decision and simply get on and fix any issues.

So we're removing the version on the rubocop dependency, so dependabot knows to always grab the latest.