### PR TITLE
Remove frozen string literal exclusion for rspec

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -110,15 +110,3 @@ Style/BlockDelimiters:
 # value in using "" for all strings irrespective of whether string interpolation is used
 Style/StringLiterals:
   EnforcedStyle: double_quotes
-
-# There is no reason to set frozen literals within specs or factories as it will cause issues with specs
-Style/FrozenStringLiteralComment:
-  Enabled: true
-  Exclude:
-    - "spec/*_helper.rb"
-    - "spec/dummy/**/**/**/*"
-    - "spec/**/**/*_spec.rb"
-    - "spec/shared_examples/*.rb"
-    - "spec/**/support/**/*.rb"
-    - "**/spec/factories/**/*.rb"
-    - "**/spec/support/shared_examples/*.rb"


### PR DESCRIPTION
The exclusion was added for fear that specs would be affected by using frozen strings, however on reflection it was noted that we as yet have not experienced any issues where the comment is added.

Also the rspec team appear to be working on ensuring compliance with it (see <https://github.com/rspec/rspec-core/issues/2264>). So we've decided we should be adding this magic comment and exposing any issues upfront, rather than being caught by surprise later.