### PR TITLE
Remove multiline block exclusion for specs

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -101,11 +101,6 @@ Metrics/ModuleLength:
 Style/Documentation:
   Enabled: false
 
-# We seem to use multi-line blocks in our specs.
-Style/BlockDelimiters:
-  Exclude:
-    - "**/spec/**/*_spec.rb"
-
 # There are no relative performance improvements using '' over "", therefore we believe there is more
 # value in using "" for all strings irrespective of whether string interpolation is used
 Style/StringLiterals:


### PR DESCRIPTION
The exclusion was added (which then permits multiline blocks in specs) because it appears we are currently doing this.

However we shouldn't be unless we have good cause to, so removing it from the default rules so any violations are highlighted.