### PR TITLE
Add travis ci integration to the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+rvm: 2.4.2
+cache: bundler
+
+# Travis CI clones repositories to a depth of 50 commits, which is only really
+# useful if you are performing git operations.
+# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+git:
+  depth: 3
+
+before_install:
+  - export TZ=UTC
+
+script:
+  - bundle exec rubocop

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 <img src="/defra-ruby-style.png" alt="Defra ruby style logo" />
 
+[![Build Status](https://travis-ci.com/DEFRA/defra-ruby-style.svg?branch=master)](https://travis-ci.com/DEFRA/defra-ruby-style)
+
 This repository is used to manage the ruby code style we use at DEFRA.
 
 ## Installation
 
-Add the following to your Gemfile
+Add the following to your `Gemfile`
 
 ```ruby
 group :test, :development do


### PR DESCRIPTION
The project has one dependency, rubocop and no actual code files in this project. We have the project hooked up to [Dependabot](https://dependabot.com/) which is likely to update this dependency on occasion.

We want some form of CI to run when this happens to ensure that rubocop will still run using the default config.

We also want to know that as we change the default rules in `default.yml` rubocop will still run.

Hence this change integrates the project with Travis, and when travis runs the test is to see if rubocop runs.