### PR TITLE
Update project to enable auto deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,11 @@ before_install:
 
 script:
   - bundle exec rubocop
+
+deploy:
+  provider: rubygems
+  gem: defra_ruby_style
+  on:
+    tags: true
+  api_key:
+    secure: "QLFon2vPZx+iopHsocowzONVTS9Ks2jwA54kfgkicHQNJyv8Gyb5Zer3t0WNc4d+bdVOQoFeHY/vjVh3dSEP5q+0RBbYUPbr769J6LGQrDlmmfdHtMI8rAY5+P/2qmrw2ZY7+yAelMe6pxDes3BN0Kk5lSlpaWo5GRcUgEpn9p39KtC71UWrX9/sCpgsspUgflqhhZfWI40oNf6nfxQ8y/qhsJ1pquBuY9QoKzCCdXHq7HocOgGjbjwC7iLmlNI/FEXRBLBvlZ+kSyCU4NurQ7COYU2AvQoVEb1KBCUO2xoAlId9v/Uzen46HasgeU3ot7IeXqPC+DvHA826Rvt6HyVlxG76mqcMw4/wV3C04hrUAxuV8ajmScIIXAO5SfvGs3yuJg0dRFk0C4TqqAP0vQWvZZGBP21vATVO5/SGL/KdXIzGhSVVq1eOkn401Uo/lKOoc9vsbM9H0qsujzZD34oJOQoeMf5Ims15x5XR7Gdd7h/gfyP9aWnjVpx4lCvpv/DNygeCDrrgk3/jesILNLIi3Y+bj0YLMABZSXIVH77Fxh4Jk+9mC8tqw24+FTsoJtkwC5hvZveca5KqEg2ajNdNBHC2KWwhY2W7AFfTuVh/Q1/qrCOe7g+sQoxvpFpCCuRlJy8h71UiSkRYj5OHUxxlYMVnmA493SUZPhDsjI4="

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ Add the following to your `Gemfile`
 
 ```ruby
 group :test, :development do
-  gem "defra_ruby_style",
-      git: "https://github.com/DEFRA/defra-ruby-style",
-      branch: "master"
+  gem "defra_ruby_style"
 end
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,71 @@
+# Releasing
+
+As the gem is a dependency in a number of services we build and deploy it to [Rubygems](https://rubygems.org/gems/defra_ruby_style) so we can properly version it, and the dependent services can manage which versions they take.
+
+This means as changes are made, we will also need to update the version of the gem published to Rubygems. The following outlines the steps to take.
+
+## Decide on the version
+
+Assuming changes have been made to the project, the first step is deciding when to cut a new release. This will determine the version number assigned because as best as we can, we try to follow [Semver](https://semver.org/).
+
+Essentially
+
+- breaking changes to the API should result in a **MAJOR** version change
+- adding new functionality, major changes to dependencies, or large scale housekeeping overhauls should result in a **MINOR** version change
+- fixes, minor changes to dependencies, and minor housekeeping tasks should result in a **PATCH** version change
+
+## Update version.rb
+
+Update `lib/defra_ruby_style/version.rb` to match the version number you intend to release with.
+
+```ruby
+module Defra
+  module Style
+    VERSION = "0.0.1"
+  end
+end
+```
+
+Commit the change and push to **master**. We don't create a PR for this as we rely on PR's to provide the content for our [CHANGELOG](CHANGELOG.md), so this would just make for a redundant entry.
+
+## Tag the repo
+
+Assuming that has built successfully in Travis, then tag the repo and push the new tag
+
+```bash
+git tag -a v0.0.1 -m "Version 0.0.1"
+git push origin v0.0.1
+```
+
+[Travis-CI](https://travis-ci.org/DEFRA/defra-ruby-style) is automatically configured to build and deploy the updated gem to Rubygems when it sees a new tag pushed. It will only succeed though if the new version does not match one that has already been published to Rubygems.
+
+Hence it's important to update the `version.rb` before creating and pushing the new tag.
+
+## Update CHANGELOG
+
+With the new version published we can update the [CHANGELOG](CHANGELOG.md). This is automatically done via a rake task.
+
+```bash
+bundle exec rake changelog
+```
+
+Commit the changes to `CHANGELOG.md` and push to **master**. Again like the version change we don't create a PR for this as we don't want PR's for updating the CHANGELOG becoming noise in its content.
+
+## Publish release
+
+In GitHub select the releases page for the project, then click 'Draft a new release'. Select the version tag we've just released, leave target as master, and set the release title as **Version #.#.#**. In the description simply copy the content from the CHANGELOG for the release.
+
+```markdown
+# v0.0.1 (2019-01-08)
+
+[Full changelog](https://github.com/DEFRA/defra-ruby-style/blob/master/CHANGELOG.md#v001-2019-01-08)
+
+## Merged pull requests:
+
+- Update project to enable auto deployments #17 (Cruikshanks)
+- Add travis ci integration to the project #16 (Cruikshanks)
+- Make path patterns consistent in default.yml #15 (Cruikshanks)
+- Remove multiline block exclusion for specs #14 (Cruikshanks)
+```
+
+Save the changes and you're done.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+begin
+  require "bundler/setup"
+rescue LoadError
+  puts "You must `gem install bundler` and `bundle install` to run rake tasks"
+end
+
+Bundler::GemHelper.install_tasks
+
+require "github_changelog_generator/task"
+
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+end

--- a/defra_ruby_style.gemspec
+++ b/defra_ruby_style.gemspec
@@ -6,32 +6,38 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 require "defra/style/version"
 
 # Describe your gem and declare its dependencies:
-Gem::Specification.new do |spec|
-  spec.name        = "defra_ruby_style"
-  spec.version     = Defra::Style::VERSION.dup
-  spec.authors     = ["Defra"]
-  spec.email       = ["alan.cruikshanks@environment-agency.gov.uk"]
-  spec.license     = "The Open Government Licence (OGL) Version 3"
-  spec.homepage    = "https://github.com/DEFRA/defra-ruby-style"
-  spec.summary     = "Defra ruby coding standards"
-  spec.description = "A gem to simplify the process of ensuring ruby based "\
+Gem::Specification.new do |s|
+  s.name        = "defra_ruby_style"
+  s.version     = Defra::Style::VERSION.dup
+  s.authors     = ["Defra"]
+  s.email       = ["alan.cruikshanks@environment-agency.gov.uk"]
+  s.license     = "The Open Government Licence (OGL) Version 3"
+  s.homepage    = "https://github.com/DEFRA/defra-ruby-style"
+  s.summary     = "Defra ruby coding standards"
+  s.description = "A gem to simplify the process of ensuring ruby based "\
                      "Defra projects are using our agreed coding style and "\
                      "standards."
 
-  spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-
-  spec.require_paths = ["lib"]
+  s.files = Dir["{bin,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
+  s.require_paths = ["lib"]
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "https://rubygems.org"
+  if s.respond_to?(:metadata)
+    s.metadata["allowed_push_host"] = "https://rubygems.org"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."
   end
 
-  spec.add_dependency "rubocop"
+  s.add_dependency "rubocop"
+
+  # Allows us to automatically generate the change log from the tags, issues,
+  # labels and pull requests on GitHub. Added as a dependency so all dev's have
+  # access to it to generate a log, and so they are using the same version.
+  # New dev's should first create GitHub personal app token and add it to their
+  # ~/.bash_profile (or equivalent)
+  # https://github.com/skywinder/github-changelog-generator#github-token
+  s.add_development_dependency "github_changelog_generator"
+  s.add_development_dependency "rake"
 end


### PR DESCRIPTION
As a shared gem that multiple services are dependent on, our pattern is to version and deploy the gem to rubygems.

This makes the changes more visible, and allows us to hook up Dependabot in such a way that when a change is made to this gem, it will automate updating the projects that use it and testing whether anything breaks.