### PR TITLE
Fix broken gem setup

### DIFF
--- a/defra_ruby_style.gemspec
+++ b/defra_ruby_style.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
                      "Defra projects are using our agreed coding style and "\
                      "standards."
 
-  s.files = Dir["{bin,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
+  s.files = Dir["{bin,lib}/**/*", "default.yml", "LICENSE", "Rakefile", "README.md"]
   s.require_paths = ["lib"]
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'

--- a/lib/defra/style/version.rb
+++ b/lib/defra/style/version.rb
@@ -2,6 +2,6 @@
 
 module Defra
   module Style
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
When we updated the gemspec in prepping this gem for publishing to rubygems, we broke it. We left out including `default.yml` which meant when used by another project rubocop fails because it cannot find this file.

This change fixes the error.