### PR TITLE
Add support for Capistrano Capfile

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -14,6 +14,7 @@ AllCops:
     - "**/*.thor"
     - "**/*.rb"
     - "**/*.ru"
+    - "**/Capfile"
     - "**/Gemfile"
     - "**/Rakefile"
   Exclude:
@@ -94,6 +95,12 @@ Metrics/ModuleLength:
     - "spec/**/*_spec.rb"
     - "spec/factories/**/*.rb"
     - "spec/support/shared_examples/**/*.rb"
+
+Naming/Filename:
+  Exclude:
+    # This is the expected root filename for a capistrano project. However it
+    # breaks rubocop's filename rules hence the exclusion
+    - "**/Capfile"
 
 # As a web app, as long as the team commit to using well named classes for
 # controllers, models etc it should not be necessary to add top-level class

--- a/lib/defra/style/version.rb
+++ b/lib/defra/style/version.rb
@@ -2,6 +2,6 @@
 
 module Defra
   module Style
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end


### PR DESCRIPTION
[Capistrano](https://capistranorb.com/) is a remote server automation and deployment tool written in Ruby. As such its commonly used for deploying Rails projects, and we use it within Defra.

By convention the root file in any capistrano project is called `Capfile` however this breaks rubocop's rules on file names.

We want to use **Defra ruby style** in our capistrano projects, but without this change the `Capfile` will always get flagged.