### PR TITLE
Remove exclusion for config folder in projects

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -18,9 +18,6 @@ AllCops:
     - "**/Gemfile"
     - "**/Rakefile"
   Exclude:
-    # config contains standard files created when Rails is initialised and
-    # therefore they should be left as is
-    - "config/**/*"
     # bin contains standard files created when Rails is initialised and
     # therefore they should be left as is
     - "bin/**/*"

--- a/lib/defra/style/version.rb
+++ b/lib/defra/style/version.rb
@@ -2,6 +2,6 @@
 
 module Defra
   module Style
-    VERSION = "0.0.3"
+    VERSION = "0.1.0"
   end
 end


### PR DESCRIPTION
We spotted in a project recently that new initializers we were adding to the Rails `config/initializers` folder were not being picked up by rubocop.

A quick check of the default rules threw up that we had excluded the folder. The reason given is valid, but on reflection we make so many changes in this folder, and often add new files that it makes sense to get everything consistent.

The downside is when starting a new project we may be forced to reformat the stuff Rails generates, but overall we think it's better to have everything consistent, and that this isn't that onerous a task to do.