### PR TITLE
Fix Naming/FileName cop entry in default.yml

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -93,7 +93,7 @@ Metrics/ModuleLength:
     - "spec/factories/**/*.rb"
     - "spec/support/shared_examples/**/*.rb"
 
-Naming/Filename:
+Naming/FileName:
   Exclude:
     # This is the expected root filename for a capistrano project. However it
     # breaks rubocop's filename rules hence the exclusion

--- a/lib/defra/style/version.rb
+++ b/lib/defra/style/version.rb
@@ -2,6 +2,6 @@
 
 module Defra
   module Style
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
Spotted when using the latest version of defra ruby style in other repos that we were getting this error message.

```
Warning: unrecognized cop Naming/Filename found in .rubocop.yml
```

A quick google and spotted that the cop name is actually `Naming::FileName` so the entry should be `Naming/FileName` hence the warning message.

This change fixes the issue.