### PR TITLE
Set memoized instance variable name to an optional enforced leading underscore

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -105,6 +105,11 @@ Naming/FileName:
 Style/Documentation:
   Enabled: false
 
+# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/MemoizedInstanceVariableName
+# We want to allow memoized instance variable names to be created with @_ and without.
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+
 # There are no relative performance improvements using '' over "", therefore we believe there is more
 # value in using "" for all strings irrespective of whether string interpolation is used
 Style/StringLiterals:

--- a/default.yml
+++ b/default.yml
@@ -99,16 +99,16 @@ Naming/FileName:
     # breaks rubocop's filename rules hence the exclusion
     - "**/Capfile"
 
+# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/MemoizedInstanceVariableName
+# We want to allow memoized instance variable names to be created with @_ and without.
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+
 # As a web app, as long as the team commit to using well named classes for
 # controllers, models etc it should not be necessary to add top-level class
 # documentation.
 Style/Documentation:
   Enabled: false
-
-# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/MemoizedInstanceVariableName
-# We want to allow memoized instance variable names to be created with @_ and without.
-Naming/MemoizedInstanceVariableName:
-  EnforcedStyleForLeadingUnderscores: optional
 
 # There are no relative performance improvements using '' over "", therefore we believe there is more
 # value in using "" for all strings irrespective of whether string interpolation is used


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/MemoizedInstanceVariableName

When using an instance variable to cache operation that we only want to do once, we
agree to use the format `@_method_name ||= SomeOperation`. This makes it clearer that
the instance variable should never be referred to directly but always throught its attr accessor
method.
Memoized variables are commonly used to allow a Lazy load/computation of the attribute itself.