### PR TITLE
Add Hakiri badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="/defra-ruby-style.png" alt="Defra ruby style logo" />
 
 [![Build Status](https://travis-ci.com/DEFRA/defra-ruby-style.svg?branch=master)](https://travis-ci.com/DEFRA/defra-ruby-style)
+[![security](https://hakiri.io/github/DEFRA/defra-ruby-style/master.svg)](https://hakiri.io/github/DEFRA/defra-ruby-style/master)
 [![Gem Version](https://badge.fury.io/rb/defra_ruby_style.svg)](https://badge.fury.io/rb/defra_ruby_style)
 [![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 


### PR DESCRIPTION
Normally we hook all our repos up to [Hakiri](https://hakiri.io) however we must have missed this one. So we have now done this and added the badge to the README with this change.