### PR TITLE
Specify pessimistic version for Rubocop

### DIFF
--- a/defra_ruby_style.gemspec
+++ b/defra_ruby_style.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
       "public gem pushes."
   end
 
-  s.add_dependency "rubocop"
+  s.add_dependency "rubocop", "~> 0.75"
 
   # Allows us to automatically generate the change log from the tags, issues,
   # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/lib/defra/style/version.rb
+++ b/lib/defra/style/version.rb
@@ -2,6 +2,6 @@
 
 module Defra
   module Style
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
Hakiri is flagging a security issue with the project

> [CVE-2017-8418](https://hakiri.io/technologies/rubocop/issues/6e12d31ab4de2e) - RuboCop 0.48.1 and earlier does not use /tmp in safe way, allowing local users to exploit this to tamper with cache files belonging to other users.

It has been patched in later versions, and that's what we are using throughout our projects. However because we don't specify a version in our gemspec Hakiri will keep flagging us, because theoretically a user could use our gem with an old version of rubocop.

So this update adds pessimistic versioning for the rubocop dependency. This should have the effect of saying this is the minimum version of rubocop that can be used, whilst still allowing us to take an future releases.