### PR TITLE
Update rubocop

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -40,6 +40,16 @@ Layout/EmptyLinesAroundClassBody:
 Layout/EmptyLinesAroundBlockBody:
   Enabled: false
 
+# We believe the default 80 characters is too restrictive and that lines can
+# still be readable and maintainable when no more than 120 characters. This also
+# allows us to maximise our screen space.
+Layout/LineLength:
+  Max: 120
+  Exclude:
+    - "spec/**/*_spec.rb"
+    - "spec/factories/**/*.rb"
+    - "spec/support/shared_examples/**/*.rb"
+
 # It's okay to use `catch { foo }` in specs
 #
 # https://github.com/rubocop-hq/rubocop/issues/4222
@@ -66,16 +76,6 @@ Metrics/BlockLength:
     - "**/*.gemspec"
     - "spec/**/*_spec.rb"
     - "spec/shared_examples/**/*.rb"
-    - "spec/factories/**/*.rb"
-    - "spec/support/shared_examples/**/*.rb"
-
-# We believe the default 80 characters is too restrictive and that lines can
-# still be readable and maintainable when no more than 120 characters. This also
-# allows us to maximise our screen space.
-Metrics/LineLength:
-  Max: 120
-  Exclude:
-    - "spec/**/*_spec.rb"
     - "spec/factories/**/*.rb"
     - "spec/support/shared_examples/**/*.rb"
 

--- a/defra_ruby_style.gemspec
+++ b/defra_ruby_style.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
       "public gem pushes."
   end
 
-  s.add_dependency "rubocop", "~> 0.75"
+  s.add_dependency "rubocop", "~> 0.79"
 
   # Allows us to automatically generate the change log from the tags, issues,
   # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/lib/defra/style/version.rb
+++ b/lib/defra/style/version.rb
@@ -2,6 +2,6 @@
 
 module Defra
   module Style
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end


### PR DESCRIPTION
Spotted when running rubocop in some of our repos we were getting the following warning

```bash
default.yml: Metrics/LineLength has the wrong namespace - should be Layout
```

So along with fixing that issue, also decided to take this opportunity to ensure we are using the latest release of rubocop by bumping our minimum in the `.gemspec`.