### PR TITLE
Fix changelog generator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,6 @@ Bundler::GemHelper.install_tasks
 require "github_changelog_generator/task"
 
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.user = "DEFRA"
+  config.project = "defra-ruby-style"
 end


### PR DESCRIPTION
It seems since v1.15.0 dropped last year that the generator has lost the ability to determine the user and project from the current repo its run in.

Now when I run it I have to call the gem directly and pass these in as arguments to get it to run.

So this change resolves the issue, and means we can go back to using `bundle exec rake changelog`.