### PR TITLE
Fix rubocop versioning in Gemfile

### DIFF
--- a/defra_ruby_style.gemspec
+++ b/defra_ruby_style.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
       "public gem pushes."
   end
 
-  s.add_dependency "rubocop", "~> 0.79"
+  s.add_dependency "rubocop", "~> 0.82"
 
   # Allows us to automatically generate the change log from the tags, issues,
   # labels and pull requests on GitHub. Added as a dependency so all dev's have


### PR DESCRIPTION
PR https://github.com/DEFRA/defra-ruby-style/pull/30 thought it was updating the version of rubocop we were using, and also the new config that goes with it.

However it omitted to actually update the Gemfile to explicitly say we wanted the latest. This change fixes that.