### PR TITLE
Exclude node_modules from rubocop

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -37,6 +37,9 @@ AllCops:
     ## schema.rb is generated automatically based on migrations, so leave as is
     - "**/db/schema.rb"
     - "db/migrate*/**/*.rb"
+    # node_modules is generated in projects using webpacker. The .rb files it
+    # contains are generated so we want to exclude.
+    - "node_modules/**/*"
     # Skip dummy application files as they're only used for testing purposes
     - "spec/dummy/**/*"
 


### PR DESCRIPTION
https://github.com/DEFRA/waste-exemptions-front-office/pull/351

We are currently working on upgrading the [Waste Carriers](https://github.com/DEFRA/ruby-services-team/tree/master/services/wcr), [Waste Exemptions](https://github.com/DEFRA/ruby-services-team/tree/master/services/wex) and [Flood Risk Activity Exemptions](https://github.com/DEFRA/ruby-services-team/tree/master/services/frae) to Ruby 2.7 and Rails 6.

Part of this update will then be switching to using [webpacker](https://github.com/rails/webpacker) for our asset compilation. We have a demonstration branch open currently which shows how to make the switch.

However, its failing because rubocop is finding issues with the generated .rb files in the `node_modules` folder that gets created when the assets are compiled. This is generated code and nothing to do with us. So we want to exclude it from rubocop.